### PR TITLE
Improve API: `none` type, vector interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## Unreleased
+
+### Added
+
+- `none` type, vector interface, [PR-4](https://github.com/panda-official/DriftBytes/pull/4)
+
 ## 0.2.0 - 2023-07-31
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ using drift_bytes::Variant;
 int main() {
   Variant some_value{42};
 
-  OutputBuffer buffer;
-  buffer.push_back(some_value);
+  OutputBuffer buffer(1);
+  buffer[0] = some_value;
 
   InputBuffer input(buffer.str());
-  Variant new_val = input.pop();
+  Variant new_val = input[0];
 
   std::cout << new_val << std::endl;
 }

--- a/cmake/drift_bytes-config.cmake.in
+++ b/cmake/drift_bytes-config.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(Cereal REQUIRED)
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/conan/test_package/src/example.cc
+++ b/conan/test_package/src/example.cc
@@ -9,11 +9,11 @@ using drift_bytes::Variant;
 int main() {
   Variant some_value{42};
 
-  OutputBuffer buffer;
-  buffer.push_back(some_value);
+  OutputBuffer buffer(1);
+  buffer[0] = some_value;
 
   InputBuffer input(buffer.str());
-  Variant new_val = input.pop();
+  Variant new_val = input[0];
 
   std::cout << new_val << std::endl;
 }

--- a/drift_bytes/bytes.h
+++ b/drift_bytes/bytes.h
@@ -50,10 +50,25 @@ using VarElement =
                  int64_t, uint64_t, float, double, std::string>;
 using VarArray = std::vector<VarElement>;
 
+/**
+ * @brief The Variant class
+ * @details This class is used to store a single value or a vector of values of
+ * different types.
+ */
 class Variant {
  public:
+  /**
+   * @brief Default constructor
+   * @details Creates a Variant of type None
+   */
   Variant() : type_(kNone), shape_({0}), data_() {}
 
+  /**
+   * @brief Construct a new Variant object
+   * @details Use first element of data to determine type
+   * @param shape
+   * @param data
+   */
   Variant(Shape shape, VarArray data)
       : type_(), shape_(std::move(shape)), data_(std::move(data)) {
     auto size = std::accumulate(shape_.begin(), shape_.end(), 1,
@@ -70,6 +85,11 @@ class Variant {
     type_ = static_cast<Type>(data_[0].index());
   }
 
+  /**
+   * @brief Construct a new Variant object from a single value
+   * @tparam T
+   * @param value
+   */
   template <typename T>
   explicit Variant(T value) : type_(), shape_(), data_() {
     shape_ = {1};
@@ -77,8 +97,17 @@ class Variant {
     type_ = static_cast<Type>(data_[0].index());
   }
 
+  /**
+   * @brief check if Variant is of type None
+   * @return
+   */
   [[nodiscard]] bool is_none() const { return type_ == kNone; }
 
+  /**
+   * @brief cast Variant to type T and return first element
+   * @tparam T
+   * @return
+   */
   template <typename T>
   operator T() const {
     if (type_ == kNone) {
@@ -181,186 +210,231 @@ class Variant {
   VarArray data_;
 };
 
+/**
+ * @brief The OutputBuffer class
+ * @details This class is used to deserialize a string of bytes into an array of
+ * Variants
+ */
 class InputBuffer {
  public:
+  /**
+   * @brief Construct a new Input Buffer object from a string
+   * @param bytes
+   */
   explicit InputBuffer(std::string &&bytes) {
-    buffer_ << bytes;
-    cereal::PortableBinaryInputArchive archive(buffer_);
-    uint8_t version;
-    archive(version);
+    std::stringstream buffer;
+    buffer << bytes;
 
-    if (version != kVersion) {
-      throw std::runtime_error("Version mismatch: received " +
-                               std::to_string(version) + ", expected " +
-                               std::to_string(kVersion));
-    }
-  }
+    {
+      cereal::PortableBinaryInputArchive archive(buffer);
+      uint8_t version;
+      archive(version);
 
-  std::string str() const { return buffer_.str(); }
-
-  Variant pop() {
-    cereal::PortableBinaryInputArchive archive(buffer_);
-    Type type;
-    Shape shape;
-    archive(type, shape);
-
-    auto size = std::accumulate(shape.begin(), shape.end(), 1,
-                                std::multiplies<uint32_t>());
-    VarArray data(size);
-    for (auto &value : data) {
-      switch (type) {
-        case kBool: {
-          bool bool_value;
-          archive(bool_value);
-          value = bool_value;
-          break;
-        }
-        case kInt8: {
-          int8_t int8_value;
-          archive(int8_value);
-          value = int8_value;
-          break;
-        }
-        case kUInt8: {
-          uint8_t uint8_value;
-          archive(uint8_value);
-          value = uint8_value;
-          break;
-        }
-
-        case kInt16: {
-          int16_t int16_value;
-          archive(int16_value);
-          value = int16_value;
-          break;
-        }
-        case kUInt16: {
-          uint16_t uint16_value;
-          archive(uint16_value);
-          value = uint16_value;
-          break;
-        }
-        case kInt32: {
-          int32_t int32_value;
-          archive(int32_value);
-          value = int32_value;
-          break;
-        }
-        case kUInt32: {
-          uint32_t uint32_value;
-          archive(uint32_value);
-          value = uint32_value;
-          break;
-        }
-        case kInt64: {
-          int64_t int64_value;
-          archive(int64_value);
-          value = int64_value;
-          break;
-        }
-        case kUInt64: {
-          uint64_t uint64_value;
-          archive(uint64_value);
-          value = uint64_value;
-          break;
-        }
-        case kFloat32: {
-          float float_value;
-          archive(float_value);
-          value = float_value;
-          break;
-        }
-        case kFloat64: {
-          double double_value;
-          archive(double_value);
-          value = double_value;
-          break;
-        }
-        case kString: {
-          std::string string_value;
-          archive(string_value);
-          value = string_value;
-          break;
-        }
-        case kNone: {
-          throw std::runtime_error("None");
-        }
-
-        default:
-          throw std::runtime_error("Unknown type");
+      if (version != kVersion) {
+        throw std::runtime_error("Version mismatch: received " +
+                                 std::to_string(version) + ", expected " +
+                                 std::to_string(kVersion));
       }
     }
 
-    return {shape, data};
+    while (buffer.rdbuf()->in_avail() != 0) {
+      cereal::PortableBinaryInputArchive arc(buffer);
+
+      Type type;
+      Shape shape;
+      arc(type, shape);
+
+      auto size = std::accumulate(shape.begin(), shape.end(), 1,
+                                  std::multiplies<uint32_t>());
+      VarArray data(size);
+      for (auto &value : data) {
+        switch (type) {
+          case kBool: {
+            bool bool_value;
+            arc(bool_value);
+            value = bool_value;
+            break;
+          }
+          case kInt8: {
+            int8_t int8_value;
+            arc(int8_value);
+            value = int8_value;
+            break;
+          }
+          case kUInt8: {
+            uint8_t uint8_value;
+            arc(uint8_value);
+            value = uint8_value;
+            break;
+          }
+
+          case kInt16: {
+            int16_t int16_value;
+            arc(int16_value);
+            value = int16_value;
+            break;
+          }
+          case kUInt16: {
+            uint16_t uint16_value;
+            arc(uint16_value);
+            value = uint16_value;
+            break;
+          }
+          case kInt32: {
+            int32_t int32_value;
+            arc(int32_value);
+            value = int32_value;
+            break;
+          }
+          case kUInt32: {
+            uint32_t uint32_value;
+            arc(uint32_value);
+            value = uint32_value;
+            break;
+          }
+          case kInt64: {
+            int64_t int64_value;
+            arc(int64_value);
+            value = int64_value;
+            break;
+          }
+          case kUInt64: {
+            uint64_t uint64_value;
+            arc(uint64_value);
+            value = uint64_value;
+            break;
+          }
+          case kFloat32: {
+            float float_value;
+            arc(float_value);
+            value = float_value;
+            break;
+          }
+          case kFloat64: {
+            double double_value;
+            arc(double_value);
+            value = double_value;
+            break;
+          }
+          case kString: {
+            std::string string_value;
+            arc(string_value);
+            value = string_value;
+            break;
+          }
+          case kNone: {
+            throw std::runtime_error("None");
+          }
+
+          default:
+            throw std::runtime_error("Unknown type");
+        }
+      }
+
+      data_.emplace_back(std::move(shape), std::move(data));
+    }
   }
 
-  bool empty() const { return buffer_.rdbuf()->in_avail() == 0; }
+  /**
+   * @brief pop a Variant from the buffer
+   * @return
+   */
+  [[deprecated("Use operator[]")]] Variant pop() {
+    if (data_.empty()) {
+      throw std::runtime_error("Buffer is empty");
+    }
+    auto variant = data_.front();
+    data_.erase(data_.begin());
+    return variant;
+  }
+
+  Variant operator[](size_t index) const { return data_[index]; }
+
+  [[nodiscard]] bool empty() const { return data_.empty(); }
 
  private:
-  std::stringstream buffer_;
+  std::vector<Variant> data_;
 };
 
 class OutputBuffer {
  public:
-  OutputBuffer() : buffer_() {
-    cereal::PortableBinaryOutputArchive archive(buffer_);
-    archive(kVersion);
-  }
+  OutputBuffer() : data_() {}
 
-  std::string str() const { return buffer_.str(); }
+  explicit OutputBuffer(size_t size) : data_(size) {}
 
-  void push_back(const Variant &variant) {
-    cereal::PortableBinaryOutputArchive archive(buffer_);
-    archive(variant.type(), variant.shape());
-    for (const auto &value : variant.data()) {
-      switch (variant.type()) {
-        case kBool:
-          archive(std::get<bool>(value));
-          break;
-        case kInt8:
-          archive(std::get<int8_t>(value));
-          break;
-        case kUInt8:
-          archive(std::get<uint8_t>(value));
-          break;
-        case kInt16:
-          archive(std::get<int16_t>(value));
-          break;
-        case kUInt16:
-          archive(std::get<uint16_t>(value));
-          break;
-        case kInt32:
-          archive(std::get<int32_t>(value));
-          break;
-        case kUInt32:
-          archive(std::get<uint32_t>(value));
-          break;
-        case kInt64:
-          archive(std::get<int64_t>(value));
-          break;
-        case kUInt64:
-          archive(std::get<uint64_t>(value));
-          break;
-        case kFloat32:
-          archive(std::get<float>(value));
-          break;
-        case kFloat64:
-          archive(std::get<double>(value));
-          break;
-        case kString:
-          archive(std::get<std::string>(value));
-          break;
-        case kNone:
-          throw std::runtime_error("None");
-          break;
-        default:
-          throw std::runtime_error("Unknown type");
+  [[nodiscard]] std::string str() const {
+    std::stringstream buffer;
+    {
+      cereal::PortableBinaryOutputArchive archive(buffer);
+      archive(kVersion);
+    }
+
+    for (auto &variant : data_) {
+      cereal::PortableBinaryOutputArchive arc(buffer);
+      arc(variant.type(), variant.shape());
+      for (const auto &value : variant.data()) {
+        switch (variant.type()) {
+          case kBool:
+            arc(std::get<bool>(value));
+            break;
+          case kInt8:
+            arc(std::get<int8_t>(value));
+            break;
+          case kUInt8:
+            arc(std::get<uint8_t>(value));
+            break;
+          case kInt16:
+            arc(std::get<int16_t>(value));
+            break;
+          case kUInt16:
+            arc(std::get<uint16_t>(value));
+            break;
+          case kInt32:
+            arc(std::get<int32_t>(value));
+            break;
+          case kUInt32:
+            arc(std::get<uint32_t>(value));
+            break;
+          case kInt64:
+            arc(std::get<int64_t>(value));
+            break;
+          case kUInt64:
+            arc(std::get<uint64_t>(value));
+            break;
+          case kFloat32:
+            arc(std::get<float>(value));
+            break;
+          case kFloat64:
+            arc(std::get<double>(value));
+            break;
+          case kString:
+            arc(std::get<std::string>(value));
+            break;
+          case kNone:
+            throw std::runtime_error("None");
+            break;
+          default:
+            throw std::runtime_error("Unknown type");
+        }
       }
     }
+    return buffer.str();
   }
 
+  [[deprecated("Use operator[]")]] void push_back(const Variant &variant) {
+    data_.push_back(variant);
+  }
+
+  Variant &operator[](size_t index) { return data_.at(index); }
+
+  const Variant &operator[](size_t index) const { return data_.at(index); }
+
+  [[nodiscard]] size_t size() const { return data_.size(); }
+
+  [[nodiscard]] bool empty() const { return data_.empty(); }
+
  private:
-  std::stringstream buffer_;
+  std::vector<Variant> data_;
 };
 
 }  // namespace drift_bytes

--- a/drift_bytes/bytes.h
+++ b/drift_bytes/bytes.h
@@ -127,7 +127,9 @@ class Variant {
   }
 
   [[nodiscard]] Type type() const { return type_; }
+
   [[nodiscard]] const Shape &shape() const { return shape_; }
+
   [[nodiscard]] const VarArray &data() const { return data_; }
 
   bool operator==(const Variant &rhs) const {
@@ -339,7 +341,7 @@ class InputBuffer {
    * @brief pop a Variant from the buffer
    * @return
    */
-  [[deprecated("Use operator[]")]] Variant pop() {
+  Variant pop() {
     if (data_.empty()) {
       throw std::runtime_error("Buffer is empty");
     }
@@ -352,10 +354,16 @@ class InputBuffer {
 
   [[nodiscard]] bool empty() const { return data_.empty(); }
 
+  [[nodiscard]] size_t size() const { return data_.size(); }
+
  private:
   std::vector<Variant> data_;
 };
 
+/**
+ * @brief The OutputBuffer class
+ * @details This class is used to serialize an array of Variants into a string
+ */
 class OutputBuffer {
  public:
   OutputBuffer() : data_() {}
@@ -421,9 +429,7 @@ class OutputBuffer {
     return buffer.str();
   }
 
-  [[deprecated("Use operator[]")]] void push_back(const Variant &variant) {
-    data_.push_back(variant);
-  }
+  void push_back(const Variant &variant) { data_.push_back(variant); }
 
   Variant &operator[](size_t index) { return data_.at(index); }
 

--- a/python/README.md
+++ b/python/README.md
@@ -20,12 +20,14 @@ pip install drift-bytes
 ```python
 from drift_bytes import Variant, InputBuffer, OutputBuffer
 
-out_buf = OutputBuffer()
-out_buf.push(Variant([1, 2, 3, 4, 5, 6]))
+out_buf = OutputBuffer(3)
+out_buf[0] = None
+out_buf[1] = Variant(2)
+out_buf[2] = [1.0, 2.0, 3.0]
 
 in_buf = InputBuffer(out_buf.bytes())
 
-var = in_buf.pop()
-
-print(var.value)
+assert in_buf[0].value is None
+assert in_buf[1].value == 2
+assert in_buf[2].value == [1.0, 2.0, 3.0]
 ```

--- a/python/src/drift_bytes/bytes.py
+++ b/python/src/drift_bytes/bytes.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-docstring, too-many-public-methods, useless-super-delegation
 """Bindings for the C++ implementation of the Bytes class."""
-from types import NoneType
 from typing import List, Union, Optional
 
 import drift_bytes._drift_bytes as impl  # pylint: disable=import-error, no-name-in-module

--- a/python/src/drift_bytes/bytes.py
+++ b/python/src/drift_bytes/bytes.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-docstring, too-many-public-methods, useless-super-delegation
 """Bindings for the C++ implementation of the Bytes class."""
+from types import NoneType
 from typing import List, Union, Optional
 
 import drift_bytes._drift_bytes as impl  # pylint: disable=import-error, no-name-in-module
@@ -8,6 +9,7 @@ import drift_bytes._drift_bytes as impl  # pylint: disable=import-error, no-name
 class Variant:
     TYPES = impl.supported_types()  # pylint: disable=c-extension-no-member
     SUPPORTED_TYPES = Union[
+        None,
         bool,
         int,
         float,
@@ -20,7 +22,7 @@ class Variant:
 
     def __init__(
         self,
-        value: SUPPORTED_TYPES,
+        value: SUPPORTED_TYPES = None,
         kind: Optional[str] = None,
     ):
         """Create Variant object from value
@@ -52,7 +54,9 @@ class Variant:
 
     def _find_type(self, kind, type_error, value):  # pylint: disable=too-many-branches
         if kind is None:
-            if isinstance(value, bool):
+            if value is None:
+                kind = "none"
+            elif isinstance(value, bool):
                 kind = "bool"
             elif isinstance(value, int):
                 kind = "int64"
@@ -82,6 +86,8 @@ class Variant:
         return kind
 
     def _make_variant(self, kind, shape, value):
+        if kind == "none":
+            self._variant = impl.Variant.from_none()
         if kind == "bool":
             self._variant = impl.Variant.from_bools(shape, value)
         elif kind == "uint8":
@@ -120,6 +126,9 @@ class Variant:
     @property
     def value(self) -> SUPPORTED_TYPES:  # pylint: disable=too-many-branches
         """Get value"""
+        if self.type == "none":
+            return None
+
         if self.type == "bool":
             ary = self._variant.to_bools()
         elif self.type == "uint8":
@@ -154,22 +163,54 @@ class Variant:
 
 
 class InputBuffer:
+    """Input buffer for reading Variants from bytes"""
+
     def __init__(self, buffer: bytes):
         self._buffer = impl.InputBuffer.from_bytes(buffer)
 
     def pop(self) -> Variant:
+        """Pop a Variant from the buffer"""
         return Variant(self._buffer.pop())
 
     def empty(self) -> bool:
+        """Check if buffer is empty"""
         return self._buffer.empty()
+
+    def size(self) -> int:
+        """Get size of buffer"""
+        return self._buffer.size()
+
+    def __getitem__(self, item):
+        """Get item from buffer"""
+        return Variant(self._buffer.get(item))
 
 
 class OutputBuffer:
-    def __init__(self):
-        self._buffer = impl.OutputBuffer()
+    def __init__(self, size: int = 0):
+        """Create an empty OutputBuffer"""
+        self._buffer = impl.OutputBuffer(size)
 
-    def push(self, value: Variant):
+    def push(self, value):
+        """Push a Variant to the buffer"""
+        if not isinstance(value, Variant):
+            value = Variant(value)
+
         self._buffer.push(value._variant)  # pylint: disable=protected-access
 
+    def empty(self) -> bool:
+        """Check if buffer is empty"""
+        return self._buffer.empty()
+
+    def size(self) -> int:
+        """Get size of buffer"""
+        return self._buffer.size()
+
+    def __setitem__(self, key, value):
+        """Set item in buffer"""
+        if not isinstance(value, Variant):
+            value = Variant(value)
+        self._buffer.set(key, value._variant)  # pylint: disable=protected-access
+
     def bytes(self):
+        """Get bytes"""
         return self._buffer.bytes()

--- a/python/src/main.cc
+++ b/python/src/main.cc
@@ -36,7 +36,7 @@ PYBIND11_MODULE(_drift_bytes, m) {
         []() -> std::vector<std::string> { return kSupportedType; });
 
   auto variant = py::class_<Variant>(m, "Variant");
-  variant
+  variant.def_static("from_none", []() -> Variant { return {}; })
       .def_static("from_bools",
                   [](Shape shape, std::vector<bool> array) -> Variant {
                     VarArray var_array(array.size());
@@ -162,12 +162,21 @@ PYBIND11_MODULE(_drift_bytes, m) {
       .def_static("from_bytes",
                   [](py::bytes bytes) { return InputBuffer(std::move(bytes)); })
       .def("pop", [](InputBuffer &buffer) -> Variant { return buffer.pop(); })
-      .def("empty", [](InputBuffer &buffer) -> bool { return buffer.empty(); });
+      .def("get",
+           [](InputBuffer &buffer, size_t index) -> Variant {
+             return buffer[index];
+           })
+      .def("empty", [](InputBuffer &buffer) -> bool { return buffer.empty(); })
+      .def("size", [](InputBuffer &buffer) -> size_t { return buffer.size(); });
 
   auto output_buffer = py::class_<OutputBuffer>(m, "OutputBuffer");
-  output_buffer.def(py::init())
+  output_buffer.def(py::init([](size_t size) { return OutputBuffer(size); }))
       .def("push", [](OutputBuffer &buffer,
                       const Variant &variant) { buffer.push_back(variant); })
+      .def("set", [](OutputBuffer &buffer, size_t index,
+                     const Variant &variant) { buffer[index] = variant; })
       .def("bytes",
-           [](OutputBuffer &buffer) -> py::bytes { return buffer.str(); });
+           [](OutputBuffer &buffer) -> py::bytes { return buffer.str(); })
+      .def("size",
+           [](OutputBuffer &buffer) -> size_t { return buffer.size(); });
 }

--- a/python/tests/test_buffers.py
+++ b/python/tests/test_buffers.py
@@ -15,3 +15,17 @@ def test_input_output():
     assert var.value == [1, 2, 3, 4, 5, 6]
 
     assert in_buf.empty()
+
+
+def test_item_access():
+    """Should access items"""
+    out_buf = OutputBuffer(3)
+    out_buf[0] = None
+    out_buf[1] = Variant(2)
+    out_buf[2] = [1.0, 2.0, 3.0]
+
+    in_buf = InputBuffer(out_buf.bytes())
+
+    assert in_buf[0].value is None
+    assert in_buf[1].value == 2
+    assert in_buf[2].value == [1.0, 2.0, 3.0]

--- a/python/tests/test_variant.py
+++ b/python/tests/test_variant.py
@@ -6,6 +6,7 @@ from drift_bytes import Variant
 @pytest.mark.parametrize(
     "kind, value",
     [
+        ("none", None),
         ("bool", True),
         ("int32", 1),
         ("float32", 1.0),
@@ -25,6 +26,7 @@ def test_init(kind, value):
 @pytest.mark.parametrize(
     "kind, value",
     [
+        ("none", None),
         ("bool", True),
         ("int64", 1),
         ("float64", 1.0),

--- a/tests/bytes_test.cc
+++ b/tests/bytes_test.cc
@@ -22,17 +22,15 @@ TEST_CASE("Full test") {
                Variant({3}, {1ul, 2ul, 3ul}), Variant({3}, {1.0f, 2.0f, 3.0f}),
                Variant());
 
-  OutputBuffer out;
-  out.push_back(var1);
-  out.push_back(var2);
+  OutputBuffer out(2);
+  out[0] = var1;
+  out[1] = var2;
 
   InputBuffer in(out.str());
 
-  REQUIRE(in.pop() == var1);
+  REQUIRE(in[0] == var1);
+  REQUIRE(in[1] == var2);
   REQUIRE_FALSE(in.empty());
-
-  REQUIRE(in.pop() == var2);
-  REQUIRE(in.empty());
 }
 
 TEST_CASE("Variant: Test scalars") {

--- a/tests/bytes_test.cc
+++ b/tests/bytes_test.cc
@@ -19,7 +19,8 @@ TEST_CASE("Full test") {
   Variant var2 =
       GENERATE(Variant({2}, {true, false}), Variant({2}, {1.0, 2.0}),
                Variant({2}, {"Hello", "World"}), Variant({3}, {1l, 2l, 3l}),
-               Variant({3}, {1ul, 2ul, 3ul}), Variant({3}, {1.0f, 2.0f, 3.0f}));
+               Variant({3}, {1ul, 2ul, 3ul}), Variant({3}, {1.0f, 2.0f, 3.0f}),
+               Variant());
 
   OutputBuffer out;
   out.push_back(var1);
@@ -58,4 +59,12 @@ TEST_CASE("Variant: test stream") {
   ss << var;
 
   REQUIRE(ss.str() == "Variant(type:int32, shape:{1,3,}, data:{1,2,3,})");
+}
+
+TEST_CASE("Variant: none") {
+  Variant var;
+  REQUIRE(var.type() == Type::kNone);
+  REQUIRE(var.shape() == Shape{0});
+  REQUIRE(var.data().empty());
+  REQUIRE(var.is_none());
 }

--- a/tests/bytes_test.cc
+++ b/tests/bytes_test.cc
@@ -28,9 +28,9 @@ TEST_CASE("Full test") {
 
   InputBuffer in(out.str());
 
+  REQUIRE(in.size() == 2);
   REQUIRE(in[0] == var1);
   REQUIRE(in[1] == var2);
-  REQUIRE_FALSE(in.empty());
 }
 
 TEST_CASE("Variant: Test scalars") {


### PR DESCRIPTION
**Closes** #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the new behavior?

* `Variant` supports `None` type and has default constructor
* `InputBuffer` and `OutBuffer` have vector interfaces

### Does this PR introduce a breaking change?

No

### Other information:
